### PR TITLE
Fix regex so that it matches Scala Steward's PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - author=scala-steward
       - status-success=continuous-integration/travis-ci/pr      
-      - body~=^labels:.*semver-patch.*
+      - body~=labels:.*semver-patch
     actions:
       merge:
         method: merge


### PR DESCRIPTION
`^` matches the beginning of the PR body and not the beginning of a line.
Removing `^` should fix this rule.

I've done the same in refined:
https://github.com/fthomas/refined/commit/3b2728d7086fea8b40730b69f50180b3b2632dc5